### PR TITLE
Up the amount of training worker threads with Rdf2Vec

### DIFF
--- a/src/fizzysearch/rdf2vec.py
+++ b/src/fizzysearch/rdf2vec.py
@@ -29,6 +29,8 @@ def build_rdf2vec_index(
 
     # The imports are inside the building method so we can exclude these libraries at runtime
     # if we only want to use the index not build it.
+    import multiprocessing
+    
     import igraph as ig
     import gensim
     import xxhash
@@ -77,7 +79,11 @@ def build_rdf2vec_index(
 
     logging.debug("RDF2Vec init: now training model")
     model = gensim.models.Word2Vec(
-        sentences=data, vector_size=100, window=5, min_count=1, workers=4
+        sentences=data,
+        vector_size=100,
+        window=5,
+        min_count=1,
+        workers=multiprocessing.cpu_count(),
     )
     vectors = []
     for node_id in only_subjects:


### PR DESCRIPTION
I'm trying to index my KG with about 2M triples using https://github.com/epoz/shmarql that uses `fizzysearch.rdf2vec`. It isn't very fast though and CPU utilization is about 10%. 

Upping the amount of training workers, e.g. with `multiprocessing.cpu_count()` might help. That would, on my machine, bring the workers up from four to fourteen. As an alternative solution, it appears not to be possible to (easily) [use the GPU with Word2Vec](https://github.com/piskvorky/gensim/issues/449#issuecomment-618632186).

I'm unsure how to time any performance gain, but at least the test suite results don't change.

